### PR TITLE
Fix theme persistence across page reloads

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,57 @@ export default function RootLayout({
 }) {
   return (
     <html lang="es" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+  try {
+    const selected = localStorage.getItem('selectedTheme');
+    const themes = {
+      default: {
+        primary: '142 76% 36%',
+        secondary: '203 39% 20%',
+        accent: '142 76% 46%',
+        gradient: 'linear-gradient(135deg, #0f172a 0%, #1e293b 20%, #1e3a8a 45%, #1e3a8a 55%, #1e293b 80%, #0f172a 100%)'
+      },
+      sunset: {
+        primary: '14 90% 50%',
+        secondary: '30 90% 40%',
+        accent: '45 100% 60%',
+        gradient: 'linear-gradient(135deg, #451a03 0%, #7c2d12 18%, #ea580c 38%, #ea580c 62%, #7c2d12 82%, #451a03 100%)'
+      },
+      ocean: {
+        primary: '198 90% 50%',
+        secondary: '171 80% 40%',
+        accent: '180 100% 50%',
+        gradient: 'linear-gradient(135deg, #0c4a6e 0%, #0369a1 18%, #0ea5e9 38%, #0ea5e9 62%, #0369a1 82%, #0c4a6e 100%)'
+      },
+      amethyst: {
+        primary: '262 52% 47%',
+        secondary: '292 60% 40%',
+        accent: '320 70% 60%',
+        gradient: 'linear-gradient(135deg, #581c87 0%, #7c3aed 18%, #a855f7 38%, #a855f7 62%, #7c3aed 82%, #581c87 100%)'
+      },
+      mono: {
+        primary: '0 0% 50%',
+        secondary: '0 0% 30%',
+        accent: '0 0% 70%',
+        gradient: 'linear-gradient(135deg, #1f2937 0%, #374151 18%, #4b5563 38%, #4b5563 62%, #374151 82%, #1f2937 100%)'
+      }
+    };
+    if (selected && themes[selected]) {
+      const th = themes[selected];
+      const root = document.documentElement;
+      root.style.setProperty('--primary', th.primary);
+      root.style.setProperty('--secondary', th.secondary);
+      root.style.setProperty('--accent', th.accent);
+      document.body.style.background = th.gradient;
+    }
+  } catch (e) {}
+})();`,
+          }}
+        />
+      </head>
       <body className={`${inter.className} bg-gradient-to-br from-slate-900 via-blue-900 to-slate-800`}>
         <ThemeProvider
           attribute="class"


### PR DESCRIPTION
## Summary
- ensure stored theme is applied early on page load to avoid flicker

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: cannot reach registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688401494898832db0ffcbacd3fc6329