### PR TITLE
Fix theme colors on initial page load

### DIFF
--- a/app/dashboard/[license]/download/page.tsx
+++ b/app/dashboard/[license]/download/page.tsx
@@ -39,7 +39,10 @@ export default function DownloadPage() {
   }, [])
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-800 flex items-center justify-center p-6 text-white">
+    <div
+      className="min-h-screen flex items-center justify-center p-6 text-white"
+      style={{ background: "var(--background-gradient)" }}
+    >
       <div className="text-center space-y-4">
         <Image src="/images/purge-logo.png" alt="PURGE Logo" width={80} height={80} className="mx-auto" />
         {error ? (

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -9,7 +9,10 @@ export default function PurgeDocsPage() {
   const [activeTab, setActiveTab] = useState("install")
 
   return (
-    <div className="h-screen bg-gradient-to-br from-[#2a3284] via-[#1e2a5e] to-[#1a1f3a] overflow-hidden">
+    <div
+      className="h-screen overflow-hidden"
+      style={{ background: "var(--background-gradient)" }}
+    >
       <MobileSidebar activeTab={activeTab} setActiveTab={setActiveTab} />
       <div className="flex h-full">
         <div className="hidden lg:block">

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,7 +16,7 @@
     --secondary-foreground: 0 0% 100%;
     --muted: 203 39% 20%;
     --muted-foreground: 0 0% 70%;
-    --accent: 142 76% 36%;
+    --accent: 142 76% 46%;
     --accent-foreground: 0 0% 100%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -57,14 +57,13 @@ export default function RootLayout({
         gradient: 'linear-gradient(135deg, #1f2937 0%, #374151 18%, #4b5563 38%, #4b5563 62%, #374151 82%, #1f2937 100%)'
       }
     };
-    if (selected && themes[selected]) {
-      const th = themes[selected];
-      const root = document.documentElement;
-      root.style.setProperty('--primary', th.primary);
-      root.style.setProperty('--secondary', th.secondary);
-      root.style.setProperty('--accent', th.accent);
-      root.style.setProperty('--background-gradient', th.gradient);
-    }
+    const key = selected && themes[selected] ? selected : 'default';
+    const th = themes[key];
+    const root = document.documentElement;
+    root.style.setProperty('--primary', th.primary);
+    root.style.setProperty('--secondary', th.secondary);
+    root.style.setProperty('--accent', th.accent);
+    root.style.setProperty('--background-gradient', th.gradient);
   } catch (e) {}
 })();`,
           }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,7 +50,10 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-800 text-white flex items-center justify-center p-6">
+    <div
+      className="min-h-screen text-white flex items-center justify-center p-6"
+      style={{ background: "var(--background-gradient)" }}
+    >
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
           <div className="flex items-center justify-center gap-4 mb-6">


### PR DESCRIPTION
## Summary
- match default accent color to the theme
- ensure theme variables are set even when a theme isn't saved
- use theme gradient on login, download, and docs pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688406d7a7ec832d84e6332d16861da9