### PR TITLE
Fix voice playback when disabled

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -229,12 +229,16 @@ export default function DashboardPage() {
   const [voiceVolume, setVoiceVolume] = useState([100])
   const [soundEffects, setSoundEffects] = useState(true)
 
-  // Reproducir voz cuando cambia el arma seleccionada
+  // Reproducir voz cuando cambia el arma seleccionada si la opción está activada
   useEffect(() => {
-    if (selectedWeapon && selectedWeapon !== "__NONE__") {
+    if (
+      voicesEnabled &&
+      selectedWeapon &&
+      selectedWeapon !== "__NONE__"
+    ) {
       playWeaponVoice(selectedWeapon)
     }
-  }, [selectedWeapon])
+  }, [selectedWeapon, voicesEnabled])
 
   const applyTheme = useCallback(
     (themeValue: string) => {


### PR DESCRIPTION
## Summary
- only play weapon voice when voice feedback is enabled

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688409c3babc832dab8801e37d8422d3