### PR TITLE
Preserve voice toggle and read notifications

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -229,6 +229,26 @@ export default function DashboardPage() {
   const [voiceVolume, setVoiceVolume] = useState([100])
   const [soundEffects, setSoundEffects] = useState(true)
 
+  // Persistir estado de voz activada en localStorage
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem("voicesEnabled")
+      if (stored !== null) {
+        setVoicesEnabled(stored === "true")
+      }
+    } catch (_) {
+      /* ignore */
+    }
+  }, [])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("voicesEnabled", voicesEnabled.toString())
+    } catch (_) {
+      /* ignore */
+    }
+  }, [voicesEnabled])
+
   // Reproducir voz cuando cambia el arma seleccionada si la opción está activada
   useEffect(() => {
     if (
@@ -546,7 +566,12 @@ export default function DashboardPage() {
   )
 
   const handleLogout = () => {
-    localStorage.clear() // limpia preferencias
+    try {
+      localStorage.removeItem("licenseType")
+      localStorage.removeItem("licenseExpiresAt")
+    } catch (_) {
+      /* ignore */
+    }
     window.location.href = "/" // vuelve al login
   }
 

--- a/components/logout-button.tsx
+++ b/components/logout-button.tsx
@@ -8,11 +8,10 @@ export function LogoutButton() {
   const router = useRouter()
 
   const handleLogout = () => {
-    // Limpiar localStorage
+    // Limpiar solo datos de licencia
     localStorage.removeItem('licenseType')
     localStorage.removeItem('licenseExpiresAt')
-    localStorage.removeItem('readNotifications')
-    
+
     // Redirigir a la página de login
     router.push('/')
   }


### PR DESCRIPTION
## Summary
- persist `voicesEnabled` across refreshes
- keep read notifications when logging out

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68840b2aeec0832d97edc48be099a389