### PR TITLE
Remove docs back button and persist voice selection

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -228,6 +228,26 @@ export default function DashboardPage() {
   const [voicesEnabled, setVoicesEnabled] = useState(false)
   const [soundEffects, setSoundEffects] = useState(true)
 
+  // Load saved voice selection from localStorage
+  useEffect(() => {
+    try {
+      const savedVoice = localStorage.getItem("selectedVoice")
+      if (savedVoice && voiceOptions.some((v) => v.value === savedVoice)) {
+        setSelectedVoice(savedVoice)
+      }
+    } catch (_) {
+      /* ignore */
+    }
+  }, [])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("selectedVoice", selectedVoice)
+    } catch (_) {
+      /* ignore */
+    }
+  }, [selectedVoice])
+
   // Persistir estado de voz activada en localStorage
   useEffect(() => {
     try {
@@ -309,6 +329,7 @@ export default function DashboardPage() {
     }
   }, [selectedTheme, applyTheme])
 
+  // SOUND: Plays a short beep when the script is toggled on or off
   const playToggleFeedback = useCallback(
     (isOn: boolean) => {
       if (soundEnabled) {

--- a/components/mobile-sidebar.tsx
+++ b/components/mobile-sidebar.tsx
@@ -1,11 +1,10 @@
 "use client"
 
 import { useState } from "react"
-import { Menu, X, Settings, Download, MessageCircle, ArrowLeft, Target, HelpCircle } from "lucide-react"
+import { Menu, X, Settings, Download, MessageCircle, Target, HelpCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
-import { useRouter, useSearchParams } from "next/navigation"
 
 interface MobileSidebarProps {
   activeTab: string
@@ -22,29 +21,12 @@ const tabs = [
 
 export function MobileSidebar({ activeTab, setActiveTab }: MobileSidebarProps) {
   const [isOpen, setIsOpen] = useState(false)
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const license = searchParams.get("license")
 
   return (
     <>
       {/* Mobile Header */}
       <div className="lg:hidden bg-[#141b3c] border-b border-[#2a3284]/30 p-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-gray-400 hover:text-white hover:bg-[#2a3284]/20 p-2 h-auto"
-            onClick={() => {
-              if (license) {
-                router.push(`/dashboard/${license}`)
-              } else {
-                router.push("/")
-              }
-            }}
-          >
-            <ArrowLeft className="w-5 h-5" />
-          </Button>
           <div className="flex items-center gap-2">
             <div className="relative h-8 w-8">
               <Image src="/purgewhite.png" alt="Purge Logo" fill className="object-contain" priority />

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,10 +1,9 @@
 "use client"
 
-import { Settings, Download, MessageCircle, ArrowLeft, Target, HelpCircle } from "lucide-react"
+import { Settings, Download, MessageCircle, Target, HelpCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
-import { useRouter, useSearchParams } from "next/navigation"
 
 interface SidebarProps {
   activeTab: string
@@ -20,29 +19,12 @@ const tabs = [
 ]
 
 export function Sidebar({ activeTab, setActiveTab }: SidebarProps) {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const license = searchParams.get("license")
 
   return (
     <div className="w-72 bg-[#141b3c] border-r border-[#2a3284]/30 h-full flex flex-col relative">
       {/* Header */}
       <div className="p-4 border-b border-[#2a3284]/30 bg-[#141b3c]">
         <div className="flex items-center gap-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-gray-400 hover:text-white hover:bg-[#2a3284]/20 p-3 h-auto rounded-lg"
-            onClick={() => {
-              if (license) {
-                router.push(`/dashboard/${license}`)
-              } else {
-                router.push("/")
-              }
-            }}
-          >
-            <ArrowLeft className="w-6 h-6" />
-          </Button>
           <div className="flex items-center gap-3 flex-1">
             <div className="relative h-10 w-10 flex-shrink-0">
               <Image src="/purgewhite.png" alt="Purge Logo" fill className="object-contain" priority />


### PR DESCRIPTION
## Summary
- drop back button from docs sidebar components
- remember selected voice across sessions via localStorage
- mark where script toggle beep is produced

## Testing
- `npm run lint` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_68840ffb9944832d89c3b3536c0232ae