### PR TITLE
Improve dashboard UI behavior

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -101,6 +101,7 @@ export default function DashboardPage() {
   const [activeTab, setActiveTab] = useState("controls")
   const initialMountRef = useRef(true)
   const initialVoiceRef = useRef(true)
+  const initialVoiceChangeRef = useRef(true)
   const [isSendingDebounced, setIsSendingDebounced] = useState(false)
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -285,6 +286,21 @@ export default function DashboardPage() {
       playWeaponVoice(selectedWeapon)
     }
   }, [selectedWeapon, voicesEnabled])
+
+  // Reproducir voz cuando cambia la voz seleccionada
+  useEffect(() => {
+    if (initialVoiceChangeRef.current) {
+      initialVoiceChangeRef.current = false
+      return
+    }
+    if (
+      voicesEnabled &&
+      selectedWeapon &&
+      selectedWeapon !== "__NONE__"
+    ) {
+      playWeaponVoice(selectedWeapon)
+    }
+  }, [selectedVoice, voicesEnabled, selectedWeapon])
 
   const applyTheme = useCallback(
     (themeValue: string) => {
@@ -1218,7 +1234,7 @@ export default function DashboardPage() {
             <TabsContent value="autodetect" className="mt-6">
               <div className="grid grid-cols-1 gap-8">
                 {/* Detection Accuracy Card */}
-                <Card className="bg-gray-900/50 border-gray-700/50 shadow-xl backdrop-blur-sm md:w-1/2 mx-auto">
+                <Card className="bg-gray-900/50 border-gray-700/50 shadow-xl backdrop-blur-sm md:w-1/3">
                   <CardHeader className="pb-4">
                     <CardTitle
                       className="text-xl font-bold text-white flex items-center gap-3"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,6 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{
             __html: `(() => {
   try {
-    const selected = localStorage.getItem('selectedTheme');
     const themes = {
       default: {
         primary: '142 76% 36%',
@@ -57,9 +56,14 @@ export default function RootLayout({
         gradient: 'linear-gradient(135deg, #1f2937 0%, #374151 18%, #4b5563 38%, #4b5563 62%, #374151 82%, #1f2937 100%)'
       }
     };
-    const key = selected && themes[selected] ? selected : 'default';
-    const th = themes[key];
     const root = document.documentElement;
+    const path = window.location.pathname;
+    let key = 'default';
+    if (path.startsWith('/dashboard')) {
+      const selected = localStorage.getItem('selectedTheme');
+      if (selected && themes[selected]) key = selected;
+    }
+    const th = themes[key];
     root.style.setProperty('--primary', th.primary);
     root.style.setProperty('--secondary', th.secondary);
     root.style.setProperty('--accent', th.accent);


### PR DESCRIPTION
## Summary
- left-align detection accuracy card and reduce width
- play weapon voice when changing voice selection but not on initial load
- confine theme to dashboard via runtime script

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68841ec82c80832db5d2b61b23974fa2