### PR TITLE
Fix sound toggle behavior

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -102,6 +102,7 @@ export default function DashboardPage() {
   const initialMountRef = useRef(true)
   const initialVoiceRef = useRef(true)
   const initialVoiceChangeRef = useRef(true)
+  const initialScriptRef = useRef(true)
   const [isSendingDebounced, setIsSendingDebounced] = useState(false)
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -300,7 +301,7 @@ export default function DashboardPage() {
     ) {
       playWeaponVoice(selectedWeapon)
     }
-  }, [selectedVoice, voicesEnabled, selectedWeapon])
+  }, [selectedVoice, voicesEnabled])
 
   const applyTheme = useCallback(
     (themeValue: string) => {
@@ -362,7 +363,7 @@ export default function DashboardPage() {
           const osc = ctx.createOscillator()
           const gain = ctx.createGain()
           osc.type = "sine"
-          osc.frequency.value = isOn ? 880 : 220
+          osc.frequency.value = isOn ? 550 : 220
           osc.connect(gain)
           gain.connect(ctx.destination)
           osc.start()
@@ -378,6 +379,10 @@ export default function DashboardPage() {
   const handleScriptEnabledChange = useCallback(
     (val: boolean) => {
       setScriptEnabled(val)
+      if (initialScriptRef.current) {
+        initialScriptRef.current = false
+        return
+      }
       playToggleFeedback(val)
     },
     [playToggleFeedback],


### PR DESCRIPTION
## Summary
- adjust beep frequency when enabling script
- prevent initial voice/sound playback on page load
- fix double voice playback when switching weapons

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688421d49b24832d8c54df5ff4d469f4