### PR TITLE
Fix hotkey interference with UI switches

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -539,6 +539,16 @@ export default function DashboardPage() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      if (
+        target &&
+        (target.closest("input, textarea, select, button, [role='switch'], [role='button']") ||
+          target.isContentEditable)
+      ) {
+        // Ignore hotkeys when focused on interactive elements
+        return
+      }
+
       let key = event.code
       if (!KEY_NAME_TO_CODE[key] && CODE_ALIAS_MAP[key]) {
         key = CODE_ALIAS_MAP[key]


### PR DESCRIPTION
## Summary
- avoid global hotkeys firing when focused on interactive elements

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688433571d0c832da5024a92c7c8b938