### PR TITLE
Fix voicesEnabled initialization error

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -154,6 +154,20 @@ export default function DashboardPage() {
     }
   }
 
+  const [voicesEnabled, setVoicesEnabled] = useState(() => {
+    if (typeof window !== "undefined") {
+      try {
+        const stored = localStorage.getItem("voicesEnabled")
+        if (stored !== null) {
+          return stored === "true"
+        }
+      } catch (_) {
+        /* ignore */
+      }
+    }
+    return false
+  })
+
   const handleWeaponSelect = useCallback(
     (weapon: string) => {
       setSelectedWeapon(weapon)
@@ -269,19 +283,6 @@ export default function DashboardPage() {
   useEffect(() => {
     soundEnabledRef.current = soundEnabled
   }, [soundEnabled])
-  const [voicesEnabled, setVoicesEnabled] = useState(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const stored = localStorage.getItem("voicesEnabled")
-        if (stored !== null) {
-          return stored === "true"
-        }
-      } catch (_) {
-        /* ignore */
-      }
-    }
-    return false
-  })
 
   useEffect(() => {
     try {


### PR DESCRIPTION
## Summary
- initialize `voicesEnabled` state before use

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68843fe28acc832d9146dd2d30fbda28