### PR TITLE
Avoid voice playback on dashboard load

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -168,14 +168,16 @@ export default function DashboardPage() {
     return false
   })
 
+  const initialWeaponSelectRef = useRef(true)
+
   const handleWeaponSelect = useCallback(
     (weapon: string) => {
       setSelectedWeapon(weapon)
-      if (
-        voicesEnabled &&
-        weapon &&
-        weapon !== "__NONE__"
-      ) {
+      if (initialWeaponSelectRef.current) {
+        initialWeaponSelectRef.current = false
+        return
+      }
+      if (voicesEnabled && weapon && weapon !== "__NONE__") {
         playWeaponVoice(weapon)
       }
     },


### PR DESCRIPTION
## Summary
- prevent weapon voice sound on initial dashboard entry by skipping the first weapon select event

## Testing
- `npm install` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_68844641b6e0832dbdf9abe771d857cb