### PR TITLE
Adjust dashboard header layout

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -40,6 +40,7 @@ import {
   Download,
   Volume2,
   Wrench,
+  ArrowLeftCircle,
 } from "lucide-react"
 import { NotificationsDropdown } from "@/components/notifications-dropdown"
 import { submitConfiguration, fetchDashboardConfig } from "@/app/services/recoil-actions"
@@ -734,22 +735,21 @@ export default function DashboardPage() {
     >
       <div className="container mx-auto p-8">
         {/* Header */}
-        <div className="flex items-center justify-center flex-wrap gap-6 mb-12">
+        <div className="flex items-center justify-between mb-12">
           <div className="flex items-center gap-3">
+            <button
+              onClick={() => window.open("https://google.com", "_blank")}
+              title="old version"
+              className={`p-1 rounded-full border border-accent hover:bg-accent/10 ${
+                selectedTheme === "default" || selectedTheme === "mono" ? "text-accent" : "text-white"
+              }`}
+            >
+              <ArrowLeftCircle className="w-5 h-5" />
+            </button>
             <img src="/images/purge-logo.png" alt="PURGE Logo" className="h-14 w-auto" />
             <h1 className="text-3xl font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
               Purge 2.0
             </h1>
-            <a
-              href="https://google.com"
-              target="_blank"
-              rel="noopener noreferrer"
-              className={`text-xs px-2 py-1 rounded border border-accent hover:bg-accent/10 ${
-                selectedTheme === "default" || selectedTheme === "mono" ? "text-accent" : "text-white"
-              }`}
-            >
-              Antigua versión
-            </a>
           </div>
           <p
             className={`self-center ${
@@ -772,34 +772,36 @@ export default function DashboardPage() {
             </span>
           </p>
           {/* API Connection Status */}
-          <div
-            className={`inline-flex items-center gap-2 px-4 py-2 rounded-full border-2 ${selectedTheme !== "default" ? "bg-black/50" : ""}`}
-            style={{ borderColor: API_COLORS[apiConnectionStatus] }}
-          >
-            {apiConnectionStatus === "pending" && (
-              <>
-                <Loader2 className="w-4 h-4 animate-spin" style={{ color: API_COLORS.pending }} />
-                <span style={{ color: API_COLORS.pending }} className="font-medium">
-                  API Connection: Checking…
-                </span>
-              </>
-            )}
-            {apiConnectionStatus === "connected" && (
-              <>
-                <Wifi className="w-4 h-4" style={{ color: API_COLORS.connected }} />
-                <span style={{ color: API_COLORS.connected }} className="font-medium">
-                  API Connection: Active&nbsp;&amp;&nbsp;Connected
-                </span>
-              </>
-            )}
-            {apiConnectionStatus === "disconnected" && (
-              <>
-                <WifiOff className="w-4 h-4" style={{ color: API_COLORS.disconnected }} />
-                <span style={{ color: API_COLORS.disconnected }} className="font-medium">
-                  API Connection: Disconnected
-                </span>
-              </>
-            )}
+          <div className="flex-1 flex justify-center">
+            <div
+              className={`inline-flex items-center gap-2 px-4 py-2 rounded-full border-2 ${selectedTheme !== "default" ? "bg-black/50" : ""}`}
+              style={{ borderColor: API_COLORS[apiConnectionStatus] }}
+            >
+              {apiConnectionStatus === "pending" && (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" style={{ color: API_COLORS.pending }} />
+                  <span style={{ color: API_COLORS.pending }} className="font-medium">
+                    API Connection: Checking…
+                  </span>
+                </>
+              )}
+              {apiConnectionStatus === "connected" && (
+                <>
+                  <Wifi className="w-4 h-4" style={{ color: API_COLORS.connected }} />
+                  <span style={{ color: API_COLORS.connected }} className="font-medium">
+                    API Connection: Active&nbsp;&amp;&nbsp;Connected
+                  </span>
+                </>
+              )}
+              {apiConnectionStatus === "disconnected" && (
+                <>
+                  <WifiOff className="w-4 h-4" style={{ color: API_COLORS.disconnected }} />
+                  <span style={{ color: API_COLORS.disconnected }} className="font-medium">
+                    API Connection: Disconnected
+                  </span>
+                </>
+              )}
+            </div>
           </div>
           {/* Action Buttons */}
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- add `ArrowLeftCircle` icon for a temporary back button
- center the API connection status and remove the old version link
- tweak header container layout

## Testing
- `npm run lint` *(fails: `next` not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6884f5dc230c832d88271921c33b38f6