### PR TITLE
Increase spacing in dashboard header

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -734,8 +734,8 @@ export default function DashboardPage() {
     >
       <div className="container mx-auto p-8">
         {/* Header */}
-        <div className="flex items-center justify-center flex-wrap gap-6 mb-12">
-          <div className="flex items-center gap-3">
+        <div className="flex items-center justify-center flex-wrap gap-8 mb-12">
+          <div className="flex items-center gap-4">
             <img src="/images/purge-logo.png" alt="PURGE Logo" className="h-14 w-auto" />
             <h1 className="text-3xl font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
               Purge 2.0
@@ -792,8 +792,8 @@ export default function DashboardPage() {
               )}
             </div>
           {/* Action Buttons */}
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-3">
+          <div className="flex items-center gap-6">
+            <div className="flex items-center gap-4">
               <Button
                 className={`border border-accent bg-transparent hover:bg-accent/10 ${
                   selectedTheme === "default" || selectedTheme === "mono"


### PR DESCRIPTION
## Summary
- tweak dashboard header spacing for a cleaner layout

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884fb2fc41c832db1124b9e53fa84c9