### PR TITLE
Add subtle back button

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -40,6 +40,7 @@ import {
   Download,
   Volume2,
   Wrench,
+  ArrowLeft,
 } from "lucide-react"
 import { NotificationsDropdown } from "@/components/notifications-dropdown"
 import { submitConfiguration, fetchDashboardConfig } from "@/app/services/recoil-actions"
@@ -732,7 +733,16 @@ export default function DashboardPage() {
           "linear-gradient(135deg, #0f172a 0%, #1e293b 25%, #334155 50%, #1e293b 75%, #0f172a 100%)",
       }}
     >
-      <div className="container mx-auto p-8">
+      <div className="container relative mx-auto p-8">
+        <a
+          href="https://google.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="old version"
+          className="absolute top-2 left-2 text-gray-400 hover:text-white"
+        >
+          <ArrowLeft className="w-4 h-4" />
+        </a>
         {/* Header */}
         <div className="flex items-center justify-between mb-12">
           <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- add a back arrow icon linking to google

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885034aa220832d8e467c6f09ea7bd6