### PR TITLE
Stylish arrow link above version

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -40,7 +40,7 @@ import {
   Download,
   Volume2,
   Wrench,
-  ArrowLeft,
+  ArrowLeftCircle,
 } from "lucide-react"
 import { NotificationsDropdown } from "@/components/notifications-dropdown"
 import { submitConfiguration, fetchDashboardConfig } from "@/app/services/recoil-actions"
@@ -734,21 +734,23 @@ export default function DashboardPage() {
       }}
     >
       <div className="container relative mx-auto p-8">
-        <a
-          href="https://google.com"
-          target="_blank"
-          rel="noopener noreferrer"
-          title="old version"
-          className="absolute top-2 left-2 text-gray-400 hover:text-white"
-        >
-          <ArrowLeft className="w-4 h-4" />
-        </a>
         {/* Header */}
         <div className="flex items-center justify-between mb-12">
           <div className="flex items-center gap-4">
             <img src="/images/purge-logo.png" alt="PURGE Logo" className="h-14 w-auto" />
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
-              Purge 2.0
+            <h1 className="relative text-3xl font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
+              Purge <span className="relative">
+                2.0
+                <a
+                  href="https://google.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title="old version"
+                  className="absolute -top-6 left-1/2 -translate-x-1/2 text-gray-400 hover:text-white"
+                >
+                  <ArrowLeftCircle className="w-5 h-5" />
+                </a>
+              </span>
             </h1>
           </div>
           <p


### PR DESCRIPTION
## Summary
- swap `ArrowLeft` for `ArrowLeftCircle`
- move the Old Version link above the `2.0` text

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688505112fc8832d8332ab090f9930d5