### PR TITLE
Add temporary dashboard button

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -805,6 +805,11 @@ export default function DashboardPage() {
           <div className="flex items-center gap-6">
             <div className="flex items-center gap-4">
               <Button
+                className="bg-green-600 hover:bg-green-700 text-white text-lg px-6 py-3"
+              >
+                Temporary
+              </Button>
+              <Button
                 className={`border border-accent bg-transparent hover:bg-accent/10 ${
                   selectedTheme === "default" || selectedTheme === "mono"
                     ? "text-accent"


### PR DESCRIPTION
## Summary
- add a temporary green button to the dashboard next to "How to use"

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850a79b57c832da3c1fdb474e174d9