### PR TITLE
Remove Temporary button

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -805,11 +805,6 @@ export default function DashboardPage() {
           <div className="flex items-center gap-6">
             <div className="flex items-center gap-4">
               <Button
-                className="bg-green-600 hover:bg-green-700 text-white text-lg px-6 py-3"
-              >
-                Temporary
-              </Button>
-              <Button
                 className={`border border-accent bg-transparent hover:bg-accent/10 ${
                   selectedTheme === "default" || selectedTheme === "mono"
                     ? "text-accent"


### PR DESCRIPTION
## Summary
- remove unused Temporary button from dashboard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_6885142943f4832dbcdafea7b5d53d49