### PR TITLE
Fix header alignment

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -736,14 +736,14 @@ export default function DashboardPage() {
       <div className="container relative mx-auto p-8">
         {/* Removed old version link */}
         {/* Header */}
-        <div className="grid grid-cols-3 items-center justify-items-center gap-6 mb-12">
-          <div className="flex items-center gap-4 justify-start">
+        <div className="flex items-center justify-between gap-6 mb-12">
+          <div className="flex items-center gap-4">
             <img src="/images/purge-logo.png" alt="PURGE Logo" className="h-14 w-auto" />
             <h1 className="text-3xl font-bold bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
               Purge 2.0
             </h1>
           </div>
-          <div className="flex flex-col items-center gap-2">
+          <div className="flex items-center gap-4">
             <p
               className={`self-center ${
                 selectedTheme === "default" || selectedTheme === "mono"


### PR DESCRIPTION
## Summary
- tweak dashboard header
- align license and API status horizontally

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68851fff15c0832d8b2135e9bb078790