### PR TITLE
Adjust spacing around API status badge

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -743,7 +743,7 @@ export default function DashboardPage() {
               Purge 2.0
             </h1>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-6">
             <p
               className={`self-center ${
                 selectedTheme === "default" || selectedTheme === "mono"


### PR DESCRIPTION
## Summary
- add more space between the license text and API connection badge

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: blocked from reaching npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_688524e805cc832dacadd32ee8a555a9