### PR TITLE
Increase spacing between license and API info

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -743,7 +743,7 @@ export default function DashboardPage() {
               Purge 2.0
             </h1>
           </div>
-          <div className="flex items-center gap-6">
+          <div className="flex items-center gap-12">
             <p
               className={`self-center ${
                 selectedTheme === "default" || selectedTheme === "mono"


### PR DESCRIPTION
## Summary
- update dashboard header spacing so the license text and API status chip are further apart

## Testing
- `npm install` *(fails: internet access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_688530c178b8832dabc1c364926013df