### PR TITLE
Update dashboard gap spacing

### DIFF
--- a/app/dashboard/[license]/page.tsx
+++ b/app/dashboard/[license]/page.tsx
@@ -743,7 +743,7 @@ export default function DashboardPage() {
               Purge 2.0
             </h1>
           </div>
-          <div className="flex items-center gap-12">
+          <div className="flex items-center gap-24">
             <p
               className={`self-center ${
                 selectedTheme === "default" || selectedTheme === "mono"


### PR DESCRIPTION
## Summary
- adjust dashboard header spacing from gap-12 to gap-24

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688531d71c9c832d930b5b6fbbb27577