### PR TITLE
Persist theme and audio settings

### DIFF
--- a/extern api/helpers.py
+++ b/extern api/helpers.py
@@ -223,6 +223,10 @@ def build_dashboard_config(req) -> Dict:
         "script_on": req.script_on,
         "script_toggle_key": req.script_toggle_key,
         "auto_detection_toggle_key": req.auto_detection_toggle_key,
+        "selected_theme": getattr(req, "selected_theme", None),
+        "sound_enabled": getattr(req, "sound_enabled", None),
+        "voices_enabled": getattr(req, "voices_enabled", None),
+        "selected_voice": getattr(req, "selected_voice", None),
     }
 
 

--- a/extern api/routes.py
+++ b/extern api/routes.py
@@ -87,6 +87,10 @@ class RecoilReq(BaseModel):
     script_on: bool = False
     script_toggle_key: Optional[int] = None
     auto_detection_toggle_key: Optional[int] = None
+    selected_theme: Optional[str] = None
+    sound_enabled: Optional[bool] = None
+    voices_enabled: Optional[bool] = None
+    selected_voice: Optional[str] = None
 
 
 class RecoilBySerial(RecoilReq):

--- a/web/app/dashboard/[license]/page.tsx
+++ b/web/app/dashboard/[license]/page.tsx
@@ -164,19 +164,7 @@ export default function DashboardPage() {
     }
   }
 
-  const [voicesEnabled, setVoicesEnabled] = useState(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const stored = localStorage.getItem("voicesEnabled")
-        if (stored !== null) {
-          return stored === "true"
-        }
-      } catch (_) {
-        /* ignore */
-      }
-    }
-    return false
-  })
+  const [voicesEnabled, setVoicesEnabled] = useState(false)
 
   const initialWeaponSelectRef = useRef(true)
 
@@ -248,79 +236,21 @@ export default function DashboardPage() {
   const [selectedTheme, setSelectedTheme] = useState<string>(themeOptions[0].value)
   const [backgroundGradient, setBackgroundGradient] = useState<string>("")
 
-  // Load saved theme from localStorage on mount
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem("selectedTheme")
-      if (saved && themeOptions.some((t) => t.value === saved)) {
-        setSelectedTheme(saved)
-      }
-    } catch (_) {
-      /* ignore */
-    }
-  }, [])
 
   const voiceOptions = [
     { value: "britney", label: "Britney" },
     { value: "grandpa", label: "Grandpa" },
     { value: "john", label: "John" },
   ] as const
-  const [selectedVoice, setSelectedVoice] = useState<string>(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const saved = localStorage.getItem("selectedVoice")
-        if (saved && voiceOptions.some((v) => v.value === saved)) {
-          return saved
-        }
-      } catch (_) {
-        /* ignore */
-      }
-    }
-    return voiceOptions[0].value
-  })
-  const [soundEnabled, setSoundEnabled] = useState(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const stored = localStorage.getItem("soundEnabled")
-        if (stored !== null) {
-          return stored === "true"
-        }
-      } catch (_) {
-        /* ignore */
-      }
-    }
-    return true
-  })
+  const [selectedVoice, setSelectedVoice] = useState<string>(voiceOptions[0].value)
+  const [soundEnabled, setSoundEnabled] = useState(true)
   const soundEnabledRef = useRef(soundEnabled)
   useEffect(() => {
     soundEnabledRef.current = soundEnabled
   }, [soundEnabled])
 
-  useEffect(() => {
-    try {
-      localStorage.setItem("soundEnabled", soundEnabled.toString())
-    } catch (_) {
-      /* ignore */
-    }
-  }, [soundEnabled])
 
 
-  useEffect(() => {
-    try {
-      localStorage.setItem("selectedVoice", selectedVoice)
-    } catch (_) {
-      /* ignore */
-    }
-  }, [selectedVoice])
-
-
-  useEffect(() => {
-    try {
-      localStorage.setItem("voicesEnabled", voicesEnabled.toString())
-    } catch (_) {
-      /* ignore */
-    }
-  }, [voicesEnabled])
 
 
   // Reproducir voz cuando cambia la voz seleccionada
@@ -382,11 +312,6 @@ export default function DashboardPage() {
 
   useEffect(() => {
     applyTheme(selectedTheme)
-    try {
-      localStorage.setItem("selectedTheme", selectedTheme)
-    } catch (_) {
-      /* ignore */
-    }
   }, [selectedTheme, applyTheme])
 
   // SOUND: Plays a short beep when the script is toggled on or off
@@ -483,6 +408,10 @@ export default function DashboardPage() {
       if (typeof cfg.script_toggle_key === "number") setScriptToggleKey(codeToKeyName(cfg.script_toggle_key))
       if (typeof cfg.auto_detection_toggle_key === "number")
         setAutoDetectToggleKey(codeToKeyName(cfg.auto_detection_toggle_key))
+      if (typeof cfg.selected_theme === "string") setSelectedTheme(cfg.selected_theme)
+      if (typeof cfg.sound_enabled === "boolean") setSoundEnabled(cfg.sound_enabled)
+      if (typeof cfg.voices_enabled === "boolean") setVoicesEnabled(cfg.voices_enabled)
+      if (typeof cfg.selected_voice === "string") setSelectedVoice(cfg.selected_voice)
       initialWeaponSelectRef.current = false
       setConfigLoaded(true)
     }
@@ -521,6 +450,10 @@ export default function DashboardPage() {
       auto_detection_toggle_key: keyNameToCode(autoDetectToggleKey) ?? undefined,
       auto_detection: autoDetection,
       script_on: scriptEnabled,
+      selected_theme: selectedTheme,
+      sound_enabled: soundEnabled,
+      voices_enabled: voicesEnabled,
+      selected_voice: selectedVoice,
     }
   }, [
     licenseKey,
@@ -545,6 +478,10 @@ export default function DashboardPage() {
     autoDetectToggleKey,
     autoDetection,
     scriptEnabled,
+    selectedTheme,
+    soundEnabled,
+    voicesEnabled,
+    selectedVoice,
   ])
 
   useEffect(() => {

--- a/web/components/notifications-dropdown.tsx
+++ b/web/components/notifications-dropdown.tsx
@@ -15,11 +15,21 @@ interface Notification {
   priority: 'high' | 'medium' | 'low'
 }
 
+const defaultNotifications: Notification[] = [
+  {
+    id: '1',
+    title: 'NEW PURGE 2.0 IS OUT!',
+    message: 'Enjoy now the future of Purge No Recoil Scripting',
+    type: 'success',
+    timestamp: '2025-07-23T15:20:00Z',
+    priority: 'high',
+  },
+]
+
 export function NotificationsDropdown() {
-  const [notifications, setNotifications] = useState<Notification[]>([])
+  const [notifications] = useState<Notification[]>(defaultNotifications)
   const [readNotifications, setReadNotifications] = useState<Set<string>>(new Set())
   const [isOpen, setIsOpen] = useState(false)
-  const [loading, setLoading] = useState(true)
 
   // Cargar notificaciones leídas del localStorage
   useEffect(() => {
@@ -29,28 +39,6 @@ export function NotificationsDropdown() {
     }
   }, [])
 
-  // Obtener notificaciones del API
-  useEffect(() => {
-    async function fetchNotifications() {
-      try {
-        const res = await fetch('/api/notifications')
-        if (res.ok) {
-          const data = await res.json()
-          setNotifications(data)
-        }
-      } catch (error) {
-        console.error('Failed to fetch notifications:', error)
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchNotifications()
-    
-    // Actualizar cada 5 minutos
-    const interval = setInterval(fetchNotifications, 5 * 60 * 1000)
-    return () => clearInterval(interval)
-  }, [])
 
   // Calcular notificaciones no leídas
   const unreadCount = notifications.filter(n => !readNotifications.has(n.id)).length
@@ -157,12 +145,7 @@ export function NotificationsDropdown() {
 
             {/* Content */}
             <div className="max-h-80 overflow-y-auto">
-              {loading ? (
-                <div className="p-4 text-center text-gray-400">
-                  <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-green-500 mx-auto mb-2"></div>
-                  Loading notifications...
-                </div>
-              ) : notifications.length === 0 ? (
+              {notifications.length === 0 ? (
                 <div className="p-4 text-center text-gray-400">
                   <Bell className="w-8 h-8 mx-auto mb-2 opacity-50" />
                   No notifications yet

--- a/web/lib/recoilApi.ts
+++ b/web/lib/recoilApi.ts
@@ -39,6 +39,14 @@ export interface RecoilApiPayload {
   randomness?: number
   /** Whether the backend should persist the configuration */
   save_config?: boolean
+  /** Selected theme for the dashboard */
+  selected_theme?: string
+  /** Whether sound feedback is enabled */
+  sound_enabled?: boolean
+  /** Whether voice announcements are enabled */
+  voices_enabled?: boolean
+  /** Selected voice identifier */
+  selected_voice?: string
 }
 
 export interface SubmitResult {


### PR DESCRIPTION
## Summary
- save theme and audio settings in backend configuration
- extend Recoil API payload with theme and audio parameters
- record new values in FastAPI routes
- load theme and audio settings from stored config
- keep notifications local on the frontend

## Testing
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6887321b66a8832d9ea70980dfd4ffe0