### PR TITLE
Show time left for license

### DIFF
--- a/web/app/dashboard/[license]/page.tsx
+++ b/web/app/dashboard/[license]/page.tsx
@@ -62,6 +62,8 @@ export default function DashboardPage() {
       if (lt) setLicenseType(lt)
       const exp = localStorage.getItem("licenseExpiresAt")
       if (exp) setLicenseExpiresAt(exp)
+      const tl = localStorage.getItem("licenseTimeLeft")
+      if (tl) setLicenseTimeLeft(tl)
     } catch (_) {
       /* ignore */
     }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -58,6 +58,9 @@ export default function LoginPage() {
           if (result.expiresAt) {
             localStorage.setItem('licenseExpiresAt', result.expiresAt)
           }
+          if (typeof result.timeLeft === 'number') {
+            localStorage.setItem('licenseTimeLeft', String(result.timeLeft))
+          }
         } catch (_) {
           /* ignore */
         }

--- a/web/components/logout-button.tsx
+++ b/web/components/logout-button.tsx
@@ -10,6 +10,7 @@ export function LogoutButton() {
   const handleLogout = () => {
     localStorage.removeItem('licenseType')
     localStorage.removeItem('licenseExpiresAt')
+    localStorage.removeItem('licenseTimeLeft')
 
     router.push('/')
   }


### PR DESCRIPTION
## Summary
- store time left value from login
- read time left from localStorage on the dashboard
- clear the stored time left on logout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875f7c3dc0832d9e68576b13ca8f36