### PR TITLE
Show license expiration on mobile

### DIFF
--- a/web/app/dashboard/[license]/page.tsx
+++ b/web/app/dashboard/[license]/page.tsx
@@ -716,7 +716,7 @@ export default function DashboardPage() {
             </p>
             {licenseTimeLeft && (
               <p
-                className={`self-center hidden sm:block ${
+                className={`self-center ${
                   selectedTheme === "default" || selectedTheme === "mono"
                     ? "text-gray-400"
                     : "text-gray-200"


### PR DESCRIPTION
## Summary
- ensure license expiration info isn't hidden on small screens

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887651201e8832d9fdf2fff91e7a403