### PR TITLE
Add license countdown feature

### DIFF
--- a/web/app/api/license-info/[serial]/route.ts
+++ b/web/app/api/license-info/[serial]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server'
+import { fetchLicenseInfoServer } from '@/lib/server/licenseInfoApi'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ serial: string }> }
+) {
+  const { serial } = await ctx.params
+  const info = await fetchLicenseInfoServer(serial)
+  return NextResponse.json(info)
+}

--- a/web/lib/licenseInfoApi.ts
+++ b/web/lib/licenseInfoApi.ts
@@ -1,0 +1,13 @@
+import { getApiOrigin } from './apiClient'
+import { fetchJson } from './apiHelpers'
+
+export interface LicenseInfo {
+  expires_at: string | null
+  time_left: number | null
+}
+
+const ENDPOINT = `${getApiOrigin()}/license_info`
+
+export async function fetchLicenseInfo(serial: string): Promise<LicenseInfo> {
+  return fetchJson<LicenseInfo>(`${ENDPOINT}/${serial}`)
+}

--- a/web/lib/loginApi.ts
+++ b/web/lib/loginApi.ts
@@ -19,6 +19,8 @@ export async function callLoginApi(serial: string): Promise<AuthApiResult> {
     return {
       success: true,
       license: data.license,
+      licenseType: data.license_type,
+      expiresAt: data.expires_at,
       token: data.token,
       config: data.config,
     }

--- a/web/lib/server/licenseInfoApi.ts
+++ b/web/lib/server/licenseInfoApi.ts
@@ -1,0 +1,1 @@
+export { fetchLicenseInfo as fetchLicenseInfoServer } from '../licenseInfoApi'


### PR DESCRIPTION
## Summary
- create API endpoint `/license_info/{serial}` in extern api
- support fetching license info from web client
- return license type info during login
- display remaining license time in dashboard

## Testing
- `python -m py_compile *.py`
- `pytest` *(no tests discovered)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a511a0a4832da91ca2b3a4699154