### PR TITLE
Fix license time left label

### DIFF
--- a/web/app/dashboard/[license]/page.tsx
+++ b/web/app/dashboard/[license]/page.tsx
@@ -726,11 +726,15 @@ export default function DashboardPage() {
                       : "text-gray-200"
                   }`}
                 >
-                  {expiresAt === 'lifetime'
-                    ? 'Lifetime'
-                    : expiresAt === 'activate on first run'
-                    ? 'Activate on first run'
-                    : `Time left: ${timeLeft !== null ? formatTimeLeft(timeLeft) : ''}`}
+                  {`Time left: ${
+                    expiresAt === 'lifetime'
+                      ? 'Lifetime'
+                      : expiresAt === 'activate on first run'
+                      ? 'Activate on first run'
+                      : timeLeft !== null
+                      ? formatTimeLeft(timeLeft)
+                      : ''
+                  }`}
                 </p>
               )}
             </div>


### PR DESCRIPTION
## Summary
- always show `Time left:` before the license duration, even for lifetime licenses

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6887c8ec413c832da01b72db6daceef2