### PR TITLE
Prevent duplicate weapon voice playback

### DIFF
--- a/web/app/dashboard/[license]/page.tsx
+++ b/web/app/dashboard/[license]/page.tsx
@@ -136,6 +136,7 @@ export default function DashboardPage() {
   const initialVoiceChangeRef = useRef(true)
   const initialScriptRef = useRef(true)
   const voiceReadyRef = useRef(false)
+  const lastVoiceRef = useRef<string | null>(null)
   const [isSendingDebounced, setIsSendingDebounced] = useState(false)
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -181,6 +182,12 @@ export default function DashboardPage() {
     }
     const fileName = weaponFileMap[weaponName] || "None"
     const audioPath = `/voices/${selectedVoice}/${fileName}.mp3`
+
+    if (lastVoiceRef.current === audioPath) {
+      return
+    }
+
+    lastVoiceRef.current = audioPath
 
     try {
       const audio = new Audio(audioPath)


### PR DESCRIPTION
## Summary
- track the last played weapon voice in dashboard
- skip playing the same weapon voice if it matches the previously played audio

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a11b1b104832da94dae26742c6278