### PR TITLE
Fix download go back button

### DIFF
--- a/web/app/dashboard/[license]/download/page.tsx
+++ b/web/app/dashboard/[license]/download/page.tsx
@@ -58,7 +58,7 @@ export default function DownloadPage() {
             <p className="text-xl font-semibold">Your download should begin shortly.</p>
             <Button
               variant="outline"
-              onClick={() => router.back()}
+              onClick={() => router.push(`/dashboard/${licenseKey ?? ""}`)}
               className="border-gray-600 text-gray-300 hover:bg-gray-800 hover:text-white px-8 py-3 rounded-lg transition-all duration-200"
             >
               Go Back

--- a/web/app/dashboard/[license]/page.tsx
+++ b/web/app/dashboard/[license]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useState, useEffect, useRef, useCallback, useMemo } from "react"
-import { useParams } from "next/navigation"
+import { useParams, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Slider } from "@/components/ui/slider"
 import { Switch } from "@/components/ui/switch"
@@ -51,6 +51,7 @@ type ApiConnectionStatus = "pending" | "connected" | "disconnected"
 export default function DashboardPage() {
   const params = useParams()
   const licenseKey = params.license as string
+  const router = useRouter()
   const { toast } = useToast()
   const [licenseType, setLicenseType] = useState<string | null>(null)
   const [expiresAt, setExpiresAt] = useState<string | null>(null)
@@ -807,7 +808,7 @@ export default function DashboardPage() {
                   ? "text-accent"
                   : "text-white"
               }`}
-              onClick={() => window.open(`/dashboard/${licenseKey}/download`, "_blank")}
+              onClick={() => router.push(`/dashboard/${licenseKey}/download`)}
             >
               <Download className="w-4 h-4 mr-2" />
               Download


### PR DESCRIPTION
## Summary
- navigate to the download page in the same tab instead of opening a popup
- use `useRouter` to navigate back to the dashboard from download

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a6e105644832db6e3bfd07e7693cd