### PR TITLE
Fix production voice playback

### DIFF
--- a/web/app/api/voices/[voice]/[sound]/route.ts
+++ b/web/app/api/voices/[voice]/[sound]/route.ts
@@ -1,0 +1,23 @@
+import { promises as fs } from 'fs'
+import { join } from 'path'
+import { NextResponse } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  _req: Request,
+  ctx: { params: { voice: string; sound: string } },
+) {
+  const { voice, sound } = ctx.params
+  const filePath = join(process.cwd(), 'public', 'voices', voice, `${sound}.mp3`)
+  try {
+    const data = await fs.readFile(filePath)
+    return new NextResponse(data, {
+      headers: {
+        'Content-Type': 'audio/mpeg',
+      },
+    })
+  } catch {
+    return NextResponse.json({ error: 'Voice not found' }, { status: 404 })
+  }
+}

--- a/web/app/dashboard/[license]/page.tsx
+++ b/web/app/dashboard/[license]/page.tsx
@@ -181,7 +181,7 @@ export default function DashboardPage() {
       __NONE__: "None",
     }
     const fileName = weaponFileMap[weaponName] || "None"
-    const audioPath = `/voices/${selectedVoice}/${fileName}.mp3`
+    const audioPath = `/api/voices/${selectedVoice}/${fileName}`
 
     if (lastVoiceRef.current === audioPath) {
       return


### PR DESCRIPTION
## Summary
- serve weapon voice files with a Next.js API route
- update dashboard to load voices from `/api/voices`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a794833d4832d80632249bbb1ee23